### PR TITLE
Two different 'typeof' format and 'BigInt' data type

### DIFF
--- a/operators/type.js
+++ b/operators/type.js
@@ -2,6 +2,10 @@
 ? Type Operators
 
 typeof - Returns the type of a variable.
+typeof supports two forms of syntax:
+1. As an operator: typeof x
+2. As a function: typeof(x)
+In other words typeof operator works with both parentheses and without parentheses, giving the same result.
 
 instanceof - The instanceof operator tests to see if the prototype 
 property of a constructor appears anywhere in the prototype chain of 
@@ -14,6 +18,7 @@ console.log(typeof "abc"); // string
 console.log(typeof 123); // number
 console.log(typeof function () {}); // function
 console.log(typeof {}); // object
+console.log(typeof 10n); // "bigint"
 console.log(typeof null); // object
 console.log(typeof NaN); // number
 console.log(typeof undefined); // undefined


### PR DESCRIPTION
In JavaScript, the “number” type cannot represent integer values larger than (2^53-1) (that’s 9007199254740991), or less than -(2^53-1) for negatives. Sometimes we need really large numbers like in cryptography etc. So, to remove this limitation BigInt was added to the language to represent integers of any length. 
To represent BigInt we just need to put n at the end of the integer